### PR TITLE
Pull out more information about the APIs we're linting

### DIFF
--- a/find_and_lint_openapi_docs.py
+++ b/find_and_lint_openapi_docs.py
@@ -59,7 +59,7 @@ def lint_the_openapi_docs(openapi_docs):
     output_dir = os.environ['OUTPUT_DIR']
     count = 1
     for f in openapi_docs:
-        output_file = output_dir + '/' + str(count) + '.html'
+        output_file = os.path.join(output_dir, str(count) + '.html')
         os.system('OPENAPI_FILE=' + f + ' OUTPUT_FILE=' + output_file + ' npm run lint:oas')
         count = count + 1
 

--- a/find_and_lint_openapi_docs_test.py
+++ b/find_and_lint_openapi_docs_test.py
@@ -3,7 +3,7 @@ import unittest
 from unittest import mock
 from unittest.mock import Mock, patch
 
-from find_and_lint_openapi_docs import convert_to_raw_content_url, is_an_archived_repository
+from find_and_lint_openapi_docs import convert_to_raw_content_url, is_an_archived_repository, get_api_name, get_api_description
 
 
 class FindAndLintOpenApiDocsTestCase(unittest.TestCase):
@@ -41,3 +41,42 @@ class FindAndLintOpenApiDocsTestCase(unittest.TestCase):
         result = is_an_archived_repository(item)
 
         self.assertFalse(result)
+
+    @patch('find_and_lint_openapi_docs.get_api_info_object')
+    def test_get_api_name(self, my_mock):
+        html_url = 'https://github.com/test/test-api/blob/abc123/openapi.yml'
+        my_mock.return_value = {'version': '1.0.0', 'title': 'Test title', 'description': 'Test description', 'license': {'name': 'MIT'}}
+
+        result = get_api_name(html_url)
+
+        self.assertEqual('Test title', result)
+
+    @patch('find_and_lint_openapi_docs.get_api_info_object')
+    def test_get_api_name_from_file_without_title_field(self, my_mock):
+        html_url = 'https://github.com/test/test-api/blob/abc123/openapi.yml'
+        my_mock.return_value = {'version': '1.0.0', 'description': 'Test description', 'license': {'name': 'MIT'}}
+
+        result = get_api_name(html_url)
+
+        self.assertEqual('N/A', result)
+
+    @patch('find_and_lint_openapi_docs.get_api_info_object')
+    def test_get_api_description(self, my_mock):
+        html_url = 'https://github.com/test/test-api/blob/abc123/openapi.yml'
+        my_mock.return_value = {'version': '1.0.0', 'title': 'Test title', 'description': 'Test description.\n It has multiple lines.', 'license': {'name': 'MIT'}}
+
+        result = get_api_description(html_url)
+
+        self.assertEqual('Test description.', result)
+
+    @patch('find_and_lint_openapi_docs.get_api_info_object')
+    def test_get_api_description_from_file_without_description_field(self, my_mock):
+        html_url = 'https://github.com/test/test-api/blob/abc123/openapi.yml'
+        my_mock.return_value = {'version': '1.0.0', 'title': 'Test title', 'license': {'name': 'MIT'}}
+
+        result = get_api_description(html_url)
+
+        self.assertEqual('N/A', result)
+
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests~=2.27.1
+PyYAML~=6.0


### PR DESCRIPTION
When we display the data about the linting results in the dashboard, we want to
make it easier to see what the API is and what it's for at a glance. We're pulling 
out the name, description and the first line of the README and saving these to a
separate CSV file. This should also make it easier to compare with what's in the 
API catalogue.