### PR TITLE
Save metadata to file after finding OAS docs

### DIFF
--- a/find_and_lint_openapi_docs.py
+++ b/find_and_lint_openapi_docs.py
@@ -18,7 +18,6 @@ def find_openapi_docs():
 
     with open('organisations.txt') as f:
         lines = f.readlines()
-        api_metadata = []
         for line in lines:
             organisation = line.strip()
             params = {
@@ -32,13 +31,10 @@ def find_openapi_docs():
                 html_url = item['html_url']
                 if not is_an_archived_repository(item) and 'test' not in item['html_url']:
                     html_urls.append(html_url)
-                    row = [item['html_url'], get_api_name(html_url), get_api_description(html_url)]
-                    api_metadata.append(row)
 
             # Wait to avoid hitting the GitHub API secondary rate limit
             time.sleep(20)
 
-        write_api_metadata_to_file(api_metadata)
         return html_urls
 
 
@@ -75,15 +71,15 @@ def is_an_archived_repository(item):
     return response['archived']
 
 
-def write_api_metadata_to_file(descriptions):
+def write_api_metadata_to_file(html_urls):
     output_dir = os.environ['OUTPUT_DIR']
     file_path = os.path.join(output_dir, 'descriptions.csv')
     header = ['url', 'name', 'description']
     with open(file_path, 'w') as f:
         writer = csv.writer(f)
         writer.writerow(header)
-        for row in descriptions:
-            writer.writerow(row)
+        for html_url in html_urls:
+            writer.writerow([html_url, get_api_name(html_url), get_api_description(html_url)])
 
 
 def get_raw_openapi_content(url):
@@ -130,5 +126,6 @@ def get_api_description(html_url):
 
 if __name__ == '__main__':
     openapi_docs = find_openapi_docs()
+    write_api_metadata_to_file(openapi_docs)
     raw_openapi_docs = convert_github_urls_to_raw_content_urls(openapi_docs)
     lint_the_openapi_docs(raw_openapi_docs)


### PR DESCRIPTION
Before we were searching for OpenAPI documents and writing metadata
about the APIs to a file as one method. This separates it out into
two separate logical steps.